### PR TITLE
Set $XDG_DATA_HOME so that it is inside $XXH_HOME , to not polute the user's home folder with with this data.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,6 +79,7 @@ fi
 export XXH_HOME=`readlink -f $CURRENT_DIR/../../../..`
 export PATH=$CURRENT_DIR/fish-portable/bin:$PATH
 export XDG_CONFIG_HOME=$XXH_HOME/.config
+export XDG_DATA_HOME=$XXH_HOME/.local/share
 
 if [[ $HOMEPATH != '' ]]; then
   homerealpath=`readlink -f $HOMEPATH`


### PR DESCRIPTION
The Fish shell package manager Fisher and others, use $XDG_DATA_HOME which by default is set to `~/.local/share`. 