### PR TITLE
Export for Xauthority file, so X11Forwarding through xxh hermetic works

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -119,6 +119,7 @@ fi
 export XDG_CONFIG_HOME=$XDGPATH/.config
 export XDG_DATA_HOME=$XDGPATH/.local/share
 export XDG_CACHE_HOME=$XDGPATH/.cache
+export XAUTHORITY=$( getent passwd | grep -E "^$USER\:.*" | cut -d\: -f 6 )/.Xauthority
 
 for pluginrc_file in $(find $CURRENT_DIR/../../../plugins/xxh-plugin-*/build -type f -name '*prerun.sh' -printf '%f\t%p\n' 2>/dev/null | sort -k1 | cut -f2); do
   if [[ -f $pluginrc_file ]]; then


### PR DESCRIPTION
This fixes my issue #101 on xxh-xxh. I use getent to find the original $HOME because it should also work with systems that have external authentication backends. 