### PR TITLE
limit grep to one match for cases with multiple results for $USER

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -119,7 +119,7 @@ fi
 export XDG_CONFIG_HOME=$XDGPATH/.config
 export XDG_DATA_HOME=$XDGPATH/.local/share
 export XDG_CACHE_HOME=$XDGPATH/.cache
-export XAUTHORITY=$( getent passwd | grep -E "^$USER\:.*" | cut -d\: -f 6 )/.Xauthority
+export XAUTHORITY=$( getent passwd | grep -m 1 -E "^$USER\:.*" | cut -d\: -f 6 )/.Xauthority
 
 for pluginrc_file in $(find $CURRENT_DIR/../../../plugins/xxh-plugin-*/build -type f -name '*prerun.sh' -printf '%f\t%p\n' 2>/dev/null | sort -k1 | cut -f2); do
   if [[ -f $pluginrc_file ]]; then


### PR DESCRIPTION
I found that some systems I work on return multiple root entries from ```getent passwd```.
May be related to something like this https://github.com/systemd/systemd/issues/15160
