### PR TITLE
Skip if $ENV is not name=val

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,6 +54,10 @@ if [[ $EXECUTE_FILE ]]; then
 fi
 
 for env in "${ENV[@]}"; do
+  # If the env does not look like name=val, let's skip it
+  if [[ $env != *"="* ]]; then
+    continue
+  fi
   name="$( cut -d '=' -f 1 <<< "$env" )";
   val="$( cut -d '=' -f 2- <<< "$env" )";
   val=`echo $val | base64 -d`


### PR DESCRIPTION
Hi, thank you for this package.
The code looks like supposing that `ENV=("name2=val2" "name2=val2", ...)` or so, but I want to use xxh on a weird shared machine where `ENV=/path-to-script.sh`.