### PR TITLE
Change shebang of entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Support arguments (this recommend but not required):


### PR DESCRIPTION
This makes running xxh on distros where bash is not in the standard location a lot easier