### PR TITLE
Bump fish to 3.4.1.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ do
     cp $CDIR/$f $build_dir/
 done
 
-url='https://github.com/xxh/fish-portable/releases/download/3.2.0-build1/fish-portable-musl-alpine-Linux-x86_64.tar.gz'
+url='https://github.com/xxh/fish-portable/releases/download/3.4.1/fish-portable-musl-alpine-Linux-x86_64.tar.gz'
 tarname=`basename $url`
 
 cd $build_dir


### PR DESCRIPTION
[xxh-plugin-prerun-zoxide](https://github.com/xxh/xxh-plugin-prerun-zoxide) throws an error when used with fish 3.2.0, because fish `string-match` didn't have `--groups-only` back then. Updating fish solves it.