### PR TITLE
Silence getent stderr in prerun.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -142,7 +142,7 @@ export TEMP=$TMPDIR
 mkdir -p $TMPDIR
 
 if [ -x "$(command -v getent)" ]; then
-  XAUTHORITY=$( getent passwd | grep -m 1 -E "^$USER\:.*" | cut -d ":" -f 6 )/.Xauthority
+  XAUTHORITY=$( getent passwd 2>/dev/null | grep -m 1 -E "^$USER\:.*" | cut -d ":" -f 6 )/.Xauthority
   export XAUTHORITY
 else
   export XAUTHORITY=$USER_HOME/.Xauthority


### PR DESCRIPTION
On some systems with many users, getent will spit out a bunch of warnings:

```
$ getent passwd > /dev/null
error writing passwd entry: Invalid argument
error writing passwd entry: Invalid argument
error writing passwd entry: Invalid argument
error writing passwd entry: Invalid argument
error writing passwd entry: Invalid argument
error writing passwd entry: Invalid argument
error writing passwd entry: Invalid argument
```

This PR silences those errors.